### PR TITLE
allow interpreting Value::Int as f64 on deserialization

### DIFF
--- a/src/xmlfmt/de.rs
+++ b/src/xmlfmt/de.rs
@@ -162,6 +162,9 @@ impl<'de> serde::Deserializer<'de> for Value {
                     .parse()
                     .map_err(|_| serde::de::Error::invalid_value(Unexpected::Str(&v), &visitor));
                 visitor.visit_f64(x?)
+            },
+            Value::Int(v) => {
+                visitor.visit_f64(v as f64)
             }
             _ => Err(serde::de::Error::invalid_value(self.unexpected(), &visitor)),
         }


### PR DESCRIPTION
When setting parameters, roscore casts whole numbers to the integer type, so even if you do something like `rosparam set /lidar_range 1.0`, the parameter will be set to the integer 1, and querying it will give you an integer type result. With current versions of rosrust, this gives me a deserialization error if I try to `get::<f64>()` such a parameter, or have a field of a larger parameter struct that's f64, when the value of that param has been implicitly converted to an integer by roscore.

With this patch, such queries succeed, and the integer value gets implicitly converted to f64. This does not change the behavior the other way round, so floats won't get silently rounded and converted to ints or anything.

There is the edge case of very large integers that are not representable exactly in f64, but I'd argue that this is not problematic, because for that implicit conversion to happen, you'd still have to be explicitly querying for f64, which would obviously be wrong if f64 cannot hold your expected parameter value.