### PR TITLE
fix deserializing Option::Some

### DIFF
--- a/src/xmlfmt/de.rs
+++ b/src/xmlfmt/de.rs
@@ -232,20 +232,25 @@ impl<'de> serde::Deserializer<'de> for Value {
     where
         V: Visitor<'de>,
     {
-        if let Value::Array(mut v) = self {
-            let v1 = v.pop();
-            if !v.is_empty() {
-                return Err(serde::de::Error::invalid_value(
-                    Unexpected::Seq,
-                    &"array with a single element",
-                ));
+        match self {
+            Value::Array(mut v) => {
+                let v1 = v.pop();
+                if !v.is_empty() {
+                    return Err(serde::de::Error::invalid_value(
+                        Unexpected::Seq,
+                        &"array with a single element",
+                    ));
+                }
+                match v1 {
+                    Some(x) => visitor.visit_some(x),
+                    None => visitor.visit_none(),
+                }
+            },
+            
+            v => {
+                visitor.visit_some(v)
+                //Err(serde::de::Error::invalid_value(self.unexpected(), &visitor))
             }
-            match v1 {
-                Some(x) => visitor.visit_some(x),
-                None => visitor.visit_none(),
-            }
-        } else {
-            Err(serde::de::Error::invalid_value(self.unexpected(), &visitor))
         }
     }
 

--- a/src/xmlfmt/de.rs
+++ b/src/xmlfmt/de.rs
@@ -249,7 +249,6 @@ impl<'de> serde::Deserializer<'de> for Value {
             
             v => {
                 visitor.visit_some(v)
-                //Err(serde::de::Error::invalid_value(self.unexpected(), &visitor))
             }
         }
     }


### PR DESCRIPTION
Hi,

there's a bug when `Deserialize`-ing a struct that contains an `Option` as one of its fields. We use this via `rosrust` to query a substructure of interrelated configuration parameters in a typed manner.

Example to reproduce:
```rust
use serde::Deserialize;

#[derive(Debug, Deserialize)]
struct Config {
    a : String,
    b : Option<i64>,
    sub : Option<SubStruct>
}

#[derive(Debug, Deserialize)]
struct SubStruct {
    c : Option<f32>
}

fn main() {
    rosrust::init("node");
    let config = rosrust::param("/config").unwrap().get::<Config>().unwrap();
    println!("{:#?}", config);
}
```

Load this YAML file as rosparams (`rosparam load params.yaml`):
```
config:
  a: "hello"
  sub:
    c: 3.1
```

Then `cargo run` it. With the current git main branch of xml-rpc-rs, we get
```
thread 'main' panicked at src/main.rs:17:69:
called `Result::unwrap()` on an `Err` value: Server("Response data has unexpected structure: Issue while decoding data structure: invalid value: map, expected option")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With this patch, we get:
```
Config {
    a: "hello",
    b: None,
    sub: Some(
        SubStruct {
            c: Some(
                3.1,
            ),
        },
    ),
}
```

Note that `Option` now behaves as expected for the `Some` case as well as the `None` case (the latter did work already before).