### PR TITLE
replace `hyper` v0.10  with `ureq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "xml-rpc"
 readme = "README.md"
 repository = "https://github.com/adnanademovic/xml-rpc-rs"
 version = "0.1.0"
+edition = "2024"
 
 [dependencies]
 base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 base64 = "0.22.1"
 error-chain = "0.12.4"
-hyper = "0.10.15"
+ureq = "3"
 lazy_static = "1.5.0"
 regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -39,7 +39,7 @@ pub fn main() {
         bar: "baz".into(),
     };
     println!("Sending: {:?}", req);
-    let uri = "http://localhost:8080/".parse().unwrap();
+    let uri = "http://localhost:8080/";
     let res: Result<Result<TestStruct, _>, _> = client.call(&uri, "echo", req.clone());
     println!("Echo Received: {:?}", res);
     let res: Result<Result<TestStruct, _>, _> = client.call(&uri, "double", req.clone());

--- a/src/bin/threadcheck.rs
+++ b/src/bin/threadcheck.rs
@@ -32,25 +32,25 @@ fn main() {
     std::thread::sleep(Duration::from_secs(1));
 
     let t1 = std::thread::spawn(|| {
-        call::<_, _, ()>(&"http://127.0.0.1:5000".parse().unwrap(), "foo", ())
+        call::<_, _, _, ()>(&"http://127.0.0.1:5000", "foo", ())
             .unwrap()
             .unwrap();
     });
 
     let t2 = std::thread::spawn(|| {
-        call::<_, _, ()>(&"http://127.0.0.1:5000".parse().unwrap(), "bar", ())
+        call::<_, _, _, ()>(&"http://127.0.0.1:5000", "bar", ())
             .unwrap()
             .unwrap();
     });
 
     let t3 = std::thread::spawn(|| {
-        call::<_, _, ()>(&"http://127.0.0.1:5000".parse().unwrap(), "foo", ())
+        call::<_, _, _, ()>(&"http://127.0.0.1:5000", "foo", ())
             .unwrap()
             .unwrap();
     });
 
     let t4 = std::thread::spawn(|| {
-        call::<_, _, ()>(&"http://127.0.0.1:5000".parse().unwrap(), "bar", ())
+        call::<_, _, _, ()>(&"http://127.0.0.1:5000", "bar", ())
             .unwrap()
             .unwrap();
     });

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,26 +1,27 @@
 use super::error::{Result, ResultExt};
 use super::xmlfmt::{from_params, into_params, parse, Call, Fault, Params, Response};
-use hyper::{self, Client as HyperClient};
 use serde::{Deserialize, Serialize};
 use std;
-use Url;
 
-use hyper::header::Headers;
-header! { (ContentType, "ContentType") => [String] }
-
-pub fn call_value<Tkey>(uri: &Url, name: Tkey, params: Params) -> Result<Response>
+pub fn call_value<URL, Tkey>(uri: &URL, name: Tkey, params: Params) -> Result<Response>
 where
+    URL: Clone,
+    ureq::http::Uri: TryFrom<URL>,
+    <ureq::http::Uri as TryFrom<URL>>::Error: Into<ureq::http::Error>,
     Tkey: Into<String>,
 {
     Client::new()?.call_value(uri, name, params)
 }
 
-pub fn call<'a, Tkey, Treq, Tres>(
-    uri: &Url,
+pub fn call<'a, URL, Tkey, Treq, Tres>(
+    uri: &URL,
     name: Tkey,
     req: Treq,
 ) -> Result<std::result::Result<Tres, Fault>>
 where
+    URL: Clone,
+    ureq::http::Uri: TryFrom<URL>,
+    <ureq::http::Uri as TryFrom<URL>>::Error: Into<ureq::http::Error>,
     Tkey: Into<String>,
     Treq: Serialize,
     Tres: Deserialize<'a>,
@@ -28,50 +29,45 @@ where
     Client::new()?.call(uri, name, req)
 }
 
-pub struct Client {
-    client: HyperClient,
-}
+pub struct Client;
 
 impl Client {
     pub fn new() -> Result<Client> {
-        let client = HyperClient::new();
-        Ok(Client { client })
+        Ok(Client {})
     }
 
-    pub fn call_value<Tkey>(&mut self, uri: &Url, name: Tkey, params: Params) -> Result<Response>
+    pub fn call_value<URL, Tkey>(&mut self, uri: &URL, name: Tkey, params: Params) -> Result<Response>
     where
+        URL: Clone,
+        ureq::http::Uri: TryFrom<URL>,
+        <ureq::http::Uri as TryFrom<URL>>::Error: Into<ureq::http::Error>,
         Tkey: Into<String>,
     {
         use super::xmlfmt::value::ToXml;
-        let body_str = Call {
+        let body = Call {
             name: name.into(),
             params,
         }
         .to_xml();
-        let bytes: &[u8] = body_str.as_bytes();
-        let body = hyper::client::Body::BufBody(bytes, bytes.len());
 
-        let mut headers = Headers::new();
-        headers.set(ContentType("xml".to_owned()));
+        let mut response = ureq::post(uri.clone())
+            .header("Content-Type", "text/xml")
+            .send(body)
+            .chain_err(|| "Failed to run the HTTP request within ureq.")?;
 
-        let response = self
-            .client
-            .post(uri.as_ref())
-            .headers(headers)
-            .body(body)
-            .send()
-            .chain_err(|| "Failed to run the HTTP request within hyper.")?;
-
-        parse::response(response).map_err(Into::into)
+        parse::response(response.body_mut().as_reader()).map_err(Into::into)
     }
 
-    pub fn call<'a, Tkey, Treq, Tres>(
+    pub fn call<'a, URL, Tkey, Treq, Tres>(
         &mut self,
-        uri: &Url,
+        uri: &URL,
         name: Tkey,
         req: Treq,
     ) -> Result<std::result::Result<Tres, Fault>>
     where
+        URL: Clone,
+        ureq::http::Uri: TryFrom<URL>,
+        <ureq::http::Uri as TryFrom<URL>>::Error: Into<ureq::http::Error>,
         Tkey: Into<String>,
         Treq: Serialize,
         Tres: Deserialize<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ extern crate base64;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
-extern crate hyper;
-#[macro_use]
 extern crate lazy_static;
 extern crate regex;
 #[macro_use]
@@ -15,6 +13,7 @@ pub extern crate rouille;
 extern crate serde_bytes;
 extern crate serde_xml_rs;
 extern crate xml;
+pub extern crate ureq;
 
 pub mod client;
 pub mod error;
@@ -22,6 +21,5 @@ pub mod server;
 mod xmlfmt;
 
 pub use client::{call, call_value, Client};
-pub use hyper::Url;
 pub use server::Server;
 pub use xmlfmt::{from_params, into_params, Call, Fault, Params, Response, Value};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,6 @@ pub mod error;
 pub mod server;
 mod xmlfmt;
 
-pub use client::{call, call_value, Client};
-pub use server::Server;
-pub use xmlfmt::{from_params, into_params, Call, Fault, Params, Response, Value};
+pub use crate::client::{call, call_value, Client};
+pub use crate::server::Server;
+pub use crate::xmlfmt::{from_params, into_params, Call, Fault, Params, Response, Value};

--- a/src/server.rs
+++ b/src/server.rs
@@ -135,7 +135,6 @@ where
     F: Send + Sync + 'static + Fn(&rouille::Request) -> rouille::Response,
 {
     server: rouille::Server<F>,
-    // server: hyper::Server<NewService, hyper::Body>,
 }
 
 impl<F> BoundServer<F>


### PR DESCRIPTION
`hyper` v0.10 is extremely outdated, the current release is v1.6. this old version pulls in vulnerable dependencies (incl. `hyper` v0.10 itself).

rather than upgrading to `hyper` v1.6 i opted to replace it with `ureq` since this crate here is not `async` and `hyper` v1 is completely `async`. due to the very limited amount of features needed from `hyper` (just executing HTTP POST requests) it can instead be replaced with the much simpler `ureq` crate.

i initially opted for `reqwest`, however `reqwest` is primarily `async` (and uses `hyper` underneath). while it offers a `blocking` layer this causes major issues when integrating it further up the stack in an `async` context as also stated by the [`reqwest::blocking` docs].

this is a breaking change for consumers since the URLs can now just be passed as strings rather than having to call `.parse()?` on the string.

note that this is similar to, but not the same as, #8 and #11.

fixes #9

[`reqwest::blocking` docs]: https://docs.rs/reqwest/latest/reqwest/blocking/